### PR TITLE
Disable RelaxNG validation with validate parameter

### DIFF
--- a/citeproc/frontend.py
+++ b/citeproc/frontend.py
@@ -15,7 +15,7 @@ from .formatter import html
 
 
 class CitationStylesXML(object):
-    def __init__(self, f):
+    def __init__(self, f, validate=True):
         lookup = etree.ElementNamespaceClassLookup()
         namespace = lookup.get_namespace('http://purl.org/net/xbiblio/csl')
         namespace[None] = CitationStylesElement
@@ -25,39 +25,42 @@ class CitationStylesXML(object):
         self.parser = etree.XMLParser(remove_comments=True, encoding='UTF-8',
                                       no_network=True)
         self.parser.set_element_class_lookup(lookup)
-        self.schema = etree.RelaxNG(etree.parse(SCHEMA_PATH))
         self.xml = etree.parse(f, self.parser)#, base_url=".")
-        if not self.schema.validate(self.xml):
-            err = self.schema.error_log
-            #raise Exception("XML file didn't pass schema validation:\n%s" % err)
-            warn("XML file didn't pass schema validation:\n%s" % err)
-            # TODO: proper error reporting
+        if validate:
+            self.schema = etree.RelaxNG(etree.parse(SCHEMA_PATH))
+            if not self.schema.validate(self.xml):
+                err = self.schema.error_log
+                #raise Exception("XML file didn't pass schema validation:\n%s" % err)
+                warn("XML file didn't pass schema validation:\n%s" % err)
+                # TODO: proper error reporting
         self.root = self.xml.getroot()
 
 
 class CitationStylesLocale(CitationStylesXML):
-    def __init__(self, locale):
+    def __init__(self, locale, validate=True):
         locale_path = os.path.join(LOCALES_PATH, 'locales-{}.xml'.format(locale))
         try:
-            super(CitationStylesLocale, self).__init__(locale_path)
+            super(CitationStylesLocale, self).__init__(locale_path,
+                                                       validate=validate)
         except IOError:
             raise ValueError("'{}' is not a known locale".format(locale))
 
 
 class CitationStylesStyle(CitationStylesXML):
-    def __init__(self, style, locale=None):
+    def __init__(self, style, locale=None, validate=True):
         try:
             if not os.path.exists(style):
                 style = os.path.join(STYLES_PATH, '{}.csl'.format(style))
         except TypeError:
             pass
         try:
-            super(CitationStylesStyle, self).__init__(style)
+            super(CitationStylesStyle, self).__init__(
+                style, validate=validate)
         except IOError:
             raise ValueError("'{}' is not a known style".format(style))
         if locale is None:
             locale = self.root.get('default-locale', 'en-US')
-        self.root.set_locale_list(locale)
+        self.root.set_locale_list(locale, validate=validate)
 
     def has_bibliography(self):
         return self.root.bibliography is not None

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -131,7 +131,7 @@ class Style(CitationStylesElement):
                         'pt-BR': 'pt-PT',
                         'zh-TW': 'zh-CN'}
 
-    def set_locale_list(self, output_locale):
+    def set_locale_list(self, output_locale, validate=True):
         """Set up list of locales in which to search for localizable units"""
         from .frontend import CitationStylesLocale
 
@@ -159,18 +159,21 @@ class Style(CitationStylesElement):
             pass
         # 4) (locale files) chosen dialect
         try:
-            self.locales.append(CitationStylesLocale(output_locale).root)
+            self.locales.append(CitationStylesLocale(output_locale,
+                                                     validate=validate).root)
         except ValueError:
             pass
         # 5) (locale files) fall back to primary language dialect
         try:
             fallback_locale = self._locale_fallback[output_locale]
-            self.locales.append(CitationStylesLocale(fallback_locale).root)
+            self.locales.append(CitationStylesLocale(fallback_locale,
+                                                     validate=validate).root)
         except KeyError:
             pass
         # 6) (locale files) default locale (en-US)
         if output_locale != 'en-US':
-            self.locales.append(CitationStylesLocale('en-US').root)
+            self.locales.append(CitationStylesLocale('en-US',
+                                                     validate=validate).root)
         for locale in self.locales:
             locale.style = self
 


### PR DESCRIPTION
Hi,

Thanks for the great work on citeproc-py!

Because I use citeproc-py on a server with only a couple of styles, I don't need to validate the style and locale files every time a citation is rendered.
This branch adds an option to disable the RelaxNG validation when you set the validate parameter on CitationStylesStyle to False.

regards,
Jasper Op de Coul
