### PR TITLE
Avoid error when date in JSON data has no 'date-parts'.

### DIFF
--- a/citeproc/source/json.py
+++ b/citeproc/source/json.py
@@ -95,7 +95,7 @@ class CiteProcJSON(BibliographySource):
             return date_data
 
         dates = []
-        for json_date in json_data['date-parts']:
+        for json_date in json_data.get('date-parts', []):
             date = parse_single_date(json_date)
             if 'season' in json_data:
                 date['season'] = json_data['season']


### PR DESCRIPTION
This change allows support for dates that lack a 'date-parts' element, such as dates that only use a 'literal' element.
