### PR TITLE
Avoid crash when there is nothing to affix.

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -323,9 +323,11 @@ class Formatted(object):
 
 class Affixed(object):
     def wrap(self, string):
-        prefix = self.get('prefix', '')
-        suffix = self.get('suffix', '')
-        return prefix + string + suffix
+        if string is not None:
+            prefix = self.get('prefix', '')
+            suffix = self.get('suffix', '')
+            return prefix + string + suffix
+        return None
 
 
 class Delimited(object):


### PR DESCRIPTION
Method Affixed.wrap() can be passed a None argument (e.g. from Layout.render_bibliography(), when render_children() returns None). 

This change adds some validation to prevent it from crashing in that case.
