### PR TITLE
testcase for handling non-ascii character

### DIFF
--- a/tests/test.bib
+++ b/tests/test.bib
@@ -1,0 +1,12 @@
+@INPROCEEDINGS{Blakley1979,
+  AUTHOR    = {Blakley, G. R.},
+  BOOKTITLE = {Proceedings of the National Computer Conference},
+  DOI       = {10.1109/AFIPS.1979.98},
+  LOCATION  = {Los Alamitos, CA, USA},
+  PAGES     = {313},
+  PUBLISHER = {IEEE Computer Society},
+  TITLE     = {{Safeguarding cryptographic key’s}},
+  URL       = {http://www.computer.org/csdl/proceedings/afips/1979/5087/00/50870313-abs.html http://www.computer.org/csdl/proceedings/afips/1979/5087/00/50870313.pdf},
+  VOLUME    = {0},
+  YEAR      = {1979},
+}

--- a/tests/test_bibparse.py
+++ b/tests/test_bibparse.py
@@ -2,6 +2,8 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import sys
+sys.path.insert(0, '../')
 from citeproc.py2compat import *
 
 from io import StringIO
@@ -19,6 +21,10 @@ class TestBibTeXParser(TestCase):
             for name, value in entry.items():
                 print('   {}: {}'.format(name, value))
         # TODO: perform useful checks
+    
+    def test_parse_file(self):
+        filename = 'test.bib'   # file that contains a non-ascii character
+        bib_source = BibTeXParser(filename)
 
 
 # based on the sample BibTeX database by Xavier Décoret
@@ -47,7 +53,7 @@ Some {{comments} with unbalanced braces
 ....and a "commented" entry...
 
 Book{landru21,
-  author =	 {Landru, Henri D\'esir\'e},
+  author =	 {Landru, Henri Desir’e},
   title =	 {A hundred recipes for you wife},
   publisher =	 {Culinary Expert Series},
   year =	 1921


### PR DESCRIPTION
Testcase for parsing a .bib file which contains a non-ASCII character. From python 2.7, running:
`nosetests --nocapture test_bibparse.py`
shows the failure. See issue #20.
