### PR TITLE
test to handle pages field when it includes only a single value

### DIFF
--- a/tests/pages-test.bib
+++ b/tests/pages-test.bib
@@ -1,0 +1,12 @@
+@INPROCEEDINGS{Blakley1979,
+  AUTHOR    = {Blakley, G. R.},
+  BOOKTITLE = {Proceedings of the National Computer Conference},
+  DOI       = {10.1109/AFIPS.1979.98},
+  LOCATION  = {Los Alamitos, CA, USA},
+  PAGES     = {313},
+  PUBLISHER = {IEEE Computer Society},
+  TITLE     = {{Safeguarding cryptographic keys}},
+  URL       = {http://www.computer.org/csdl/proceedings/afips/1979/5087/00/50870313-abs.html http://www.computer.org/csdl/proceedings/afips/1979/5087/00/50870313.pdf},
+  VOLUME    = {0},
+  YEAR      = {1979}
+}

--- a/tests/test_bibtex.py
+++ b/tests/test_bibtex.py
@@ -31,7 +31,18 @@ class TestBibTeX(TestCase):
         for name, reference in EXTRA_NAMES:
             print('{:24}  {}'.format(name, parse_name(name)))
             self.assertEqual(parse_name(name), reference)
-
+    
+    def test_date_months(self):
+        parser = BibTeX('month-test.bib')   
+        # the contents of that file are actually unnecessary, 
+        # but need to instantiate the parser to test this method for now
+        for january in ['jan', 'JAN', '01']:
+            self.assertEqual(parser._parse_month(january), ({'month': 0}, {'month':0}))
+    
+    def test_pages(self):
+        parser = BibTeX('pages-test.bib')
+        # TODO: should confirm that the correct pages lenth is parsed
+        # but in the meantime, this test checks for error handling
 
 SPLIT_NAMES = [
     ('AA BB', ['AA BB']),


### PR DESCRIPTION
The pages-test.bib is an example of a file that fails to be parsed because it has only a single pages value. The test just tries to import/parse that file for now. A better test would actually confirm that the expected values are also present after parsing.
