### PR TITLE
BF: do not fail if name in bibtex is in human order (not comma-separrated) + strip name before splitting

### DIFF
--- a/citeproc/source/bibtex/bibtex.py
+++ b/citeproc/source/bibtex/bibtex.py
@@ -270,7 +270,7 @@ def parse_name(name):
     """Parse a BibTeX name string and split it into First, von, Last and Jr
     parts.
     """
-    parts = split_name(name)
+    parts = split_name(name.strip())
     if len(parts) == 1:       # First von Last
         first_von_last, = parts
         index = 0
@@ -293,7 +293,7 @@ def parse_name(name):
 
 def split_name(name):
     """Split a name in into parts delimited by commas (at brace-level 0), and
-    each part into words.
+    each part into words.  If name is not delimited by commas, split by spaces.
 
     Returns a list of of lists of words.
     """
@@ -319,6 +319,8 @@ def split_name(name):
     if word:
         current_part.append(word)
         parts.append(current_part)
+    if not parts:  # no comma-separated entries
+        parts = name.split()
     return parts
 
 


### PR DESCRIPTION
avoids   name 'von_last' is not defined  as if in the case of the following bib
```
@InProceedings{ mckinney-proc-scipy-2010,
          author    = { Wes McKinney },
          title     = { Data Structures for Statistical Computing in Python },
          booktitle = { Proceedings of the 9th Python in Science Conference },
          pages     = { 51 - 56 },
          year      = { 2010 },
          editor    = { St'efan van der Walt and Jarrod Millman }
        }
```
which caused duecredit to fail ;)