### PR TITLE
ASCII encoding does't support cyrillic symbols

### DIFF
--- a/citeproc/source/bibtex/bibparse.py
+++ b/citeproc/source/bibtex/bibparse.py
@@ -38,7 +38,7 @@ class BibTeXParser(dict):
                           'nov': 'November',
                           'dec': 'December'}
 
-    def __init__(self, file_or_filename, encoding='UTF-8'):
+    def __init__(self, file_or_filename, encoding='ascii'):
         try:
             self.file = open(file_or_filename, 'rt', encoding=encoding)
         except TypeError:

--- a/citeproc/source/bibtex/bibparse.py
+++ b/citeproc/source/bibtex/bibparse.py
@@ -38,7 +38,7 @@ class BibTeXParser(dict):
                           'nov': 'November',
                           'dec': 'December'}
 
-    def __init__(self, file_or_filename, encoding='ascii'):
+    def __init__(self, file_or_filename, encoding='UTF-8'):
         try:
             self.file = open(file_or_filename, 'rt', encoding=encoding)
         except TypeError:

--- a/citeproc/source/bibtex/bibtex.py
+++ b/citeproc/source/bibtex/bibtex.py
@@ -66,7 +66,7 @@ class BibTeX(BibliographySource):
              'report': REPORT,
              }
 
-    def __init__(self, filename, encoding='ascii'):
+    def __init__(self, filename, encoding='UTF-8'):
         bibtex_database = BibTeXParser(filename, encoding)
         self.preamble_macros = {}
         parse_latex(bibtex_database.preamble,


### PR DESCRIPTION
ASCII encoding does not support cyrrilic symbols, so it goes to error
`'ascii' codec can't decode byte 0xd0 in position 233: ordinal not in range(128)`
So it's impossible to work with russian bibliography, considering the fact that citeproc have russian localization file and support russian style file(gost-r-7-0-5-2008-numeric.csl)

But if you change the encoding to utf-8 everything works as it is necessary