### PR TITLE
don't fail on empty page ranges

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -659,6 +659,7 @@ class FormatNumber(object):
 
     def _format_last_page(self, first, last):
         def find_common(first, last):
+            count = 0
             for count, (f, l) in enumerate(zip(first, last)):
                 if f != l:
                     return count


### PR DESCRIPTION
A minor issue, but the formatting was bombing when it encountered page range where first == last == ''
(error was that count variable was referenced before being defined - because for an empty generator in the for loop, no count variable exists)