### PR TITLE
ENH: drop py34 and add 37 and 38 for tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps = nose


### PR DESCRIPTION
Follows bce67543dfe470be2ba387ae5ac2514bb9f7eb40 which dropped testing of py34 on travis