### PR TITLE
Read locales.json as utf-8 to fix windows read error

### DIFF
--- a/citeproc/__init__.py
+++ b/citeproc/__init__.py
@@ -39,7 +39,8 @@ VARIABLES = (['abstract', 'annote', 'archive', 'archive_location',
               'title_short', 'URL', 'version', 'year_suffix'] +
              NAMES + DATES + NUMBERS)
 
-with open(os.path.join(LOCALES_PATH, 'locales.json')) as file:
+with open(os.path.join(LOCALES_PATH, 'locales.json'),
+          encoding='utf-8') as file:
     locales_json = json.load(file)
     PRIMARY_DIALECTS = locales_json['primary-dialects']
     LANGUAGE_NAMES = locales_json['language-names']


### PR DESCRIPTION
Fix #106

This works locally on my Windows 10 machine. Please let me know if I should add anything else.