### PR TITLE
BF(workaround, Windows): cd to directory with .rnc for rnc2rng to work

### DIFF
--- a/citeproc/__init__.py
+++ b/citeproc/__init__.py
@@ -39,7 +39,8 @@ VARIABLES = (['abstract', 'annote', 'archive', 'archive_location',
               'title_short', 'URL', 'version', 'year_suffix'] +
              NAMES + DATES + NUMBERS)
 
-with open(os.path.join(LOCALES_PATH, 'locales.json')) as file:
+with open(os.path.join(LOCALES_PATH, 'locales.json'),
+          encoding='utf-8') as file:
     locales_json = json.load(file)
     PRIMARY_DIALECTS = locales_json['primary-dialects']
     LANGUAGE_NAMES = locales_json['language-names']

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,14 @@ def convert_rnc():
     import rnc2rng
 
     filename_root, _ = os.path.splitext(CSL_SCHEMA_RNC)
-    root = rnc2rng.load(CSL_SCHEMA_RNC)
+    try:
+        # To overcome an issue with rnc2rng 2.6.4 not picking up "include"ed
+        # files on Windows we need to cd to the directory first
+        curdir = os.getcwd()
+        os.chdir(os.path.dirname(CSL_SCHEMA_RNC))
+        root = rnc2rng.load(os.path.basename(CSL_SCHEMA_RNC))
+    finally:
+        os.chdir(curdir)
     with io.open(filename_root + '.rng', 'w', encoding='utf-8') as rng:
         rnc2rng.dump(root, rng)
 


### PR DESCRIPTION
This is not an ideal solution: ideally rnc2rng should be fixed, but I
would like to see if this resolves the issue we see on github CI and
does not have side effects on other OSes.