### PR TITLE
Fix AttributeError when parsing bibtex integer values

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -652,7 +652,7 @@ class FormatNumber(object):
         amp_delimiter = ' ' + self.unicode_character('AMPERSAND') + ' '
         return join((join((format_number_or_range(item)
                            for item in comma_item.split('&')), amp_delimiter)
-                     for comma_item in value.split(',')), delimiter=', ')
+                     for comma_item in str(value).split(',')), delimiter=', ')
 
     def _format_last_page(self, first, last):
         def find_common(first, last):


### PR DESCRIPTION
https://github.com/brechtm/citeproc-py/blob/6a806d34af26cc81b0708bf67cd580625fea905e/citeproc/model.py#L655
At this line, you assume this "value" variable to be a string. However, it can sometimes be an integer, thus triggering an AttributeError: `'int' object has no attribute 'split'`.
To reproduce, heres the bibtex:
```bibtex
@article{Jumper_2021,
	doi = {10.1038/s41586-021-03819-2},
	url = {https://doi.org/10.1038%2Fs41586-021-03819-2},
	year = 2021,
	month = {jul},
	publisher = {Springer Science and Business Media {LLC}},
	volume = {596},
	number = {7873},
	pages = {583--589},
	author = {John Jumper and Richard Evans and Alexander Pritzel and Tim Green and Michael Figurnov and Olaf Ronneberger and Kathryn Tunyasuvunakool and Russ Bates and Augustin {\v{Z}}{\'{\i}}dek and Anna Potapenko and Alex Bridgland and Clemens Meyer and Simon A. A. Kohl and Andrew J. Ballard and Andrew Cowie and Bernardino Romera-Paredes and Stanislav Nikolov and Rishub Jain and Jonas Adler and Trevor Back and Stig Petersen and David Reiman and Ellen Clancy and Michal Zielinski and Martin Steinegger and Michalina Pacholska and Tamas Berghammer and Sebastian Bodenstein and David Silver and Oriol Vinyals and Andrew W. Senior and Koray Kavukcuoglu and Pushmeet Kohli and Demis Hassabis},
	title = {Highly accurate protein structure prediction with {AlphaFold}},
	journal = {Nature}
}
```
So, here's the simple solution.

And, BTW, awsome project! :)