### PR TITLE
Title case fixes

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -373,13 +373,13 @@ class TextCased(object):
                 text = ' '.join(output)
             elif text_case == 'title':
                 output = []
-                prev = ':'
+                prev = ':' #This ensures first word is capitilized
                 for word in text.words():
-                    if not text.isupper() and not word.isupper():
+                    if word.islower() and (str(word) not in self._stop_words or
+                        prev in (':', '.')):
+                        word = word.capitalize_first()
+                    elif word.islower(): #Lowercase stop words
                         word = word.soft_lower()
-                        if (str(word) not in self._stop_words or
-                            prev in (':', '.')):
-                            word = word.capitalize_first()
                     prev = word[-1]
                     output.append(word)
                 text = ' '.join(output)

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -354,4 +354,3 @@ variables_ContainerTitleShort2
 bugreports_disambigHang
 disambiguate_YearSuffixWithEtAlSubsequent
 page_Chicago16                                                     # uncaught exception
-textcase_TitleCaseWithCleverBrandName


### PR DESCRIPTION
The main reason for the PR is to fix title case for titles with multiple capital letters (e.g. Three new iron-phosphate minerals from the El Ali iron meteorite, Somalia: Elaliite, Fe²⁺₈Fe³⁺ (PO₄)O₈; elkinstantonite, Fe₄(PO₄)₂O; and olsenite, KFe₄(PO₄)₃ was previously rendered as Three New Iron-phosphate Minerals from the El Ali Iron Meteorite, Somalia: Elaliite, Fe²⁺₈fe³⁺ (PO₄)O₈; Elkinstantonite, Fe₄(po₄)₂o; and Olsenite, Kfe₄(po₄)₃). The previous version lowercased a lot more that is needed for title case. 

This will fix [textcase_TitleCaseWithCleverBrandName.txt](https://github.com/citation-style-language/test-suite/blob/master/processor-tests/humans/textcase_TitleCaseWithCleverBrandName.txt), which will show up on the failed list once https://github.com/brechtm/citeproc-py/pull/139 is merged.

https://github.com/brechtm/citeproc-py/pull/138 was needed for me to run tests locally.