### PR TITLE
Add python 3.12 into supported, and skip testing on 3.7 on macos latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,13 @@ jobs:
             runs-on: macos-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
+        exclude:
+          # No older Pythons on arm64 macos-latest
+          - python-version: '3.7'
+            runs-on: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Documentation',
         'Topic :: Printing',
         'Topic :: Software Development :: Documentation',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311,py312
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,10 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
-deps = nose3
+deps = pynose
 changedir = {envtmpdir}
 commands =
     nosetests --where={toxinidir}/tests --ignore-files=citeproc-test.py


### PR DESCRIPTION
And let's see if CI kicks in at all