### PR TITLE
Clarify licensing situation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/brechtm/citeproc-py',
     keywords='csl citation html rst bibtex xml',
-    license='2-clause BSD License',
+    license='BSD-2-Clause-Views',
     classifiers = [
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
As noted in #165, the license text in the repo is `BSD-2-Clause-Views`. This patch brings `setup.py` into sync with that reality.
