### PR TITLE
release action: missing quotes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create release
         run: |
-          if [ "${{ github.event_name }}" = workflow_dispatch ]
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]
           then opts=
           else opts=--only-publish-with-release-label
           fi


### PR DESCRIPTION
The manual release workflow isn't working because of missing quotes. I'm going to merge this so I can run a release.