### PR TITLE
Remove hardcoded option for auto to onlyPublishWithReleaseLabel

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,5 +1,4 @@
 {
-    "onlyPublishWithReleaseLabel": true,
     "baseBranch": "master",
     "author": "auto <auto@nil>",
     "noVersionPrefix": false,


### PR DESCRIPTION
We already have in workflow needed support via

    ❯ grep -A 5 Create .github/workflows/release.yml
      - name: Create release run: | if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then opts= else opts=--only-publish-with-release-label fi

