### PR TITLE
tests: drop python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           - windows-latest
           - ubuntu-latest
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'


### PR DESCRIPTION
Python 3.9 is going out of support in October. We're having intermittent issues with the CI for coveralls and Python 3.9. Since the issue only seems to happen with Python 3.9, I propose dropping testing for Python 3.9. citeproc-py should continue to work fine with Python 3.9, this is just about the CI.