### PR TITLE
setup: add citeproc-py-styles to tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     install_requires=['lxml'],
     extras_require={
         'full': ['citeproc-py-styles'],
+        'tests': ['citeproc-py-styles'],
     },
     provides=[PACKAGE],
     #test_suite='nose.collector',


### PR DESCRIPTION
We're now using citeproc-py-styles in tests, so that should be a requirement for the tests. Should resolve https://github.com/citeproc-py/citeproc-py/issues/188