### PR TITLE
fix spacing changes in csl 1.0.2

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -589,17 +589,24 @@ class Parent(object):
         else:
             return None
 
-    def render_children(self, item, **kwargs):
+    def render_children(self, item, delimiter='', **kwargs):
+        # `delimiter` is the delimiter inherited from an enclosing element (a
+        # `cs:group`). `cs:choose` is transparent, so this delimiter has to be
+        # threaded through `cs:if`/`cs:else-if`/`cs:else` to delimit their
+        # rendered children (and any nested `cs:choose`).
         output = []
         for child in self.iterchildren():
             try:
-                text = child.render(item, **kwargs)
+                if isinstance(child, Choose):
+                    text = child.render(item, delimiter=delimiter, **kwargs)
+                else:
+                    text = child.render(item, **kwargs)
                 if text is not None:
                     output.append(text)
             except VariableError:
                 pass
         if output:
-            return join(output)
+            return join(output, delimiter)
         else:
             return None
 
@@ -1387,10 +1394,17 @@ class Group(CitationStylesElement, Parent, Formatted, Affixed, Delimited):
         output = []
         variable_called = False
         variable_rendered = False
+        # A `cs:group` delimiter also delimits the children of a transparent
+        # `cs:choose` child, so pass it down (see `Parent.render_children`).
+        delimiter = self.get('delimiter', '')
         for child in self.iterchildren():
             variable_called = variable_called or child.calls_variable()
             try:
-                child_text = child.render(item, context=context, **kwargs)
+                if isinstance(child, Choose):
+                    child_text = child.render(item, context=context,
+                                              delimiter=delimiter, **kwargs)
+                else:
+                    child_text = child.render(item, context=context, **kwargs)
                 if child_text is not None:
                     output.append(child_text)
                     variable_rendered = (variable_rendered or
@@ -1416,10 +1430,13 @@ class ConditionFailed(Exception):
 
 
 class Choose(CitationStylesElement, Parent):
-    def render(self, item, context=None, **kwargs):
+    def render(self, item, context=None, delimiter='', **kwargs):
+        # `cs:choose` is transparent: the delimiter of the enclosing element is
+        # forwarded to the children of the matching branch.
         for child in self.getchildren():
             try:
-                return child.render(item, context=context, **kwargs)
+                return child.render(item, context=context,
+                                    delimiter=delimiter, **kwargs)
             except ConditionFailed:
                 continue
 
@@ -1427,7 +1444,7 @@ class Choose(CitationStylesElement, Parent):
 
 
 class If(CitationStylesElement, Parent):
-    def render(self, item, context=None, **kwargs):
+    def render(self, item, context=None, delimiter='', **kwargs):
         # TODO self.get('disambiguate')
         results = []
         if 'type' in self.attrib:
@@ -1454,7 +1471,8 @@ class If(CitationStylesElement, Parent):
         if not result:
             raise ConditionFailed
 
-        return self.render_children(item, context=context, **kwargs)
+        return self.render_children(item, context=context,
+                                    delimiter=delimiter, **kwargs)
 
     def _type(self, item):
         return [typ.lower() == item.reference.type
@@ -1542,8 +1560,9 @@ class Else_If(If, CitationStylesElement):
 
 
 class Else(CitationStylesElement, Parent):
-    def render(self, item, context=None, **kwargs):
-        return self.render_children(item, context=context, **kwargs)
+    def render(self, item, context=None, delimiter='', **kwargs):
+        return self.render_children(item, context=context,
+                                    delimiter=delimiter, **kwargs)
 
 
 # utility functions

--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -1368,7 +1368,11 @@ class Label(CitationStylesElement, Formatted, Affixed, StrippedPeriods,
         else:
             return None
 
-    RE_MULTIPLE_NUMBERS = re.compile(r'\d+[^\d]+\d+')
+    # Content is plural when it holds multiple numbers separated by a list or
+    # range separator (e.g. "1, 2" or "1-3"). A period is not such a separator:
+    # it is part of a single dotted number/version (e.g. "2.0"), which stays
+    # singular ("Version 2.0", not "Versions 2.0").
+    RE_MULTIPLE_NUMBERS = re.compile(r'\d+[^\d.]+\d+')
 
     def _is_plural(self, item):
         variable = self.get('variable')


### PR DESCRIPTION
When citeproc-py-styles was updated to csl 1.0.2, a broader range of styles began being tested and tests involving spaces in a citation started failing. https://github.com/citeproc-py/citeproc-py/actions/runs/28904841547/job/85749548612. The resulting citations are very ugly.

I also added a fix for the regex for number ranges. It's not directly related to the 1.0.2 change, but showed up from a change in 1.0.2 in the style we use.

Claude did most of the work here. I'd like to merge this fairly soon since it's a pretty annoying breaking change.