### PR TITLE
Additional chicago page range formats in csl 1.0.2

### DIFF
--- a/citeproc/model.py
+++ b/citeproc/model.py
@@ -701,7 +701,7 @@ class FormatNumber(object):
 
         range_format = self.get_root().get_option('page-range-format')
         common = find_common(first, last)
-        if range_format == 'chicago':
+        if range_format in ('chicago', 'chicago-15', 'chicago-16'):
             m = re.search(r'\d+', first)
             if not m:
                 return last
@@ -714,9 +714,8 @@ class FormatNumber(object):
                 range_format = 'minimal'
             elif first_number % 100 in range(10, 100):
                 range_format = 'minimal-two'
-        if range_format in ('expanded', None):
-            index = 0
-        elif range_format == 'minimal':
+        index = 0  # 'expanded' format (and default): return the full last page
+        if range_format == 'minimal':
             index = common
         elif range_format == 'minimal-two':
             index = min(common, len(first) - 2)


### PR DESCRIPTION
CSL 1.0.2 adds two new page range formats https://docs.citationstyles.org/en/stable/specification.html?highlight=chicago#appendix-v-page-range-formats

The logic is also a bit better, so a new range_format won't error out everything.

Claude figured out the issue, but I've verified everything. 

This is a pretty annoying bug, so I'm planning on merging soon unless someone yells.