### PR TITLE
Normalize whitespace and duplicate punctuation at string seams

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,9 @@ cite references and render the bibliography.
 
 ## CSL Compatibility
 
-Currently, citeproc-py passes almost 60% of the (relevant) tests in the
+Currently, citeproc-py passes about 60% of the tests in the
 [citeproc-test suite](https://github.com/citation-style-language/test-suite).
-However, it is more than 60% complete, as
-citeproc-py doesn't take care of double spaces and repeated punctuation
-marks yet, making a good deal of the tests fail. In addition, the
-following features have not yet been implemented (there are probably
-some I forgot though):
+A non-exhaustive list of functionality that is missing includes:
 
 -  disambiguation/year-suffix
 -  et-al-subsequent-min/et-al-subsequent-use-first

--- a/citeproc/string.py
+++ b/citeproc/string.py
@@ -2,6 +2,47 @@
 from functools import wraps, reduce
 
 
+# Punctuation characters that should not be duplicated when two of them end up
+# adjacent at a concatenation seam (e.g. a suffix '.' following text that
+# already ends in '.').
+SEAM_PUNCTUATION = frozenset('.,;:!?')
+
+
+def normalize_seam(left, other):
+    """Adjust the leading characters of `other` so that concatenating it onto
+    `left` does not introduce a double space or a duplicated punctuation mark.
+
+    `left` is the accumulated string so far and `other` the piece about to be
+    appended. Only the boundary between them is considered; the interior of
+    either side (e.g. an ellipsis inside a title) is never touched. Markup
+    segments start with '<', so they are left alone. Returns `other`, possibly
+    with its first character removed."""
+    left = str(left)
+    other_str = str(other)
+    if not left or not other_str:
+        return other
+    last, first = left[-1], other_str[0]
+    # collapse a double space
+    if last == ' ' and first == ' ':
+        return _strip_first_char(other)
+    # drop a duplicated punctuation mark ('..' -> '.', ',,' -> ',', ...)
+    if last == first and first in SEAM_PUNCTUATION:
+        return _strip_first_char(other)
+    return other
+
+
+def _strip_first_char(other):
+    """Return a copy of `other` with its first character removed, preserving
+    the (Mixed)String segment structure."""
+    if isinstance(other, MixedString):
+        segments = list(other)
+        head = segments[0]
+        stripped = type(head)(str(head)[1:])
+        segments[0:1] = [stripped] if stripped != '' else []
+        return MixedString(segments)
+    return type(other)(str(other)[1:])
+
+
 def discard_empty_other(method):
     """Decorator for addition operator methods that returns the object itself if
     `other` is the empty string."""
@@ -55,6 +96,9 @@ class String(str):
 class MixedString(list):
     @discard_empty_other
     def __add__(self, other):
+        other = normalize_seam(self, other)
+        if other == '' or other == []:
+            return self
         super_obj = super(MixedString, self)
         try:
             return self.__class__(super_obj.__add__(other))

--- a/tests/failing_tests.txt
+++ b/tests/failing_tests.txt
@@ -6,7 +6,6 @@ affix_MovingPunctuation
 affix_PrefixWithDecorations
 affix_SpaceWithQuotes
 affix_WithCommas
-bugreports_AllCapsLeakage
 bugreports_ApostropheOnParticle
 bugreports_AsaSpacing
 bugreports_AsmJournals
@@ -27,7 +26,6 @@ bugreports_DisambiguationAddNamesBibliography
 bugreports_DoubleEncodedAngleBraces
 bugreports_DuplicateSpaces
 bugreports_DuplicateSpaces2
-bugreports_DuplicateSpaces3
 bugreports_DuplicateTerminalPunctuationInBibliography
 bugreports_EnvAndUrb
 bugreports_EtAlSubsequent
@@ -36,7 +34,6 @@ bugreports_FrenchApostrophe
 bugreports_GreekStyleProblems                                      # uncaught exception
 bugreports_GreekStyleTwoEditors                                    # uncaught exception
 bugreports_IeeePunctuation
-bugreports_LabelsOutOfPlace
 bugreports_LegislationCrash
 bugreports_MatchedAuthorAndDate
 bugreports_MovePunctuationInsideQuotesForLocator
@@ -53,7 +50,6 @@ bugreports_SortedIeeeItalicsFail
 bugreports_StyleError001
 bugreports_ThesisUniversityAppearsTwice
 bugreports_TitleCase
-bugreports_UndefinedBeforeVal
 bugreports_UndefinedInName3
 bugreports_UndefinedNotString
 bugreports_UndefinedStr
@@ -61,7 +57,6 @@ bugreports_YearSuffixInHarvard1
 bugreports_YearSuffixLingers
 bugreports_disambigHang
 bugreports_ikeyOne
-bugreports_parenthesis
 bugreports_parseName
 collapse_AuthorCollapse
 collapse_AuthorCollapseNoDate
@@ -87,7 +82,6 @@ date_RangeDelimiter
 date_VariousInvalidDates                                           # uncaught exception
 date_YearSuffixDelimiter
 date_YearSuffixImplicitWithNoDate
-date_YearSuffixImplicitWithNoDateOneOnly
 date_YearSuffixWithNoDate
 decorations_AndTermUnaffectedByNameDecorations
 decorations_Baseline
@@ -149,10 +143,8 @@ disambiguate_YearSuffixWithEtAlSubsequent
 disambiguate_YearSuffixWithMixedCreatorTypes
 display_AuthorAsHeading
 display_DisplayBlock
-display_LostSuffix
 display_SecondFieldAlignClone
 display_SecondFieldAlignMigratePunctuation
-etal_CitationAndBibliographyDecorationsInBibliography
 etal_UseZeroFirst
 flipflop_ApostropheInsideTag
 flipflop_Apostrophes
@@ -264,7 +256,6 @@ name_SubsequentAuthorSubstituteMultipleNames
 name_SubsequentAuthorSubstituteSingleField
 name_SubstituteInheritLabel
 name_SubstitutePartialEach
-name_TwoRolesSameRenderingSeparateRoleLabels
 name_WithNonBreakingSpace
 name_namepartAffixes
 nameattr_EtAlUseFirstOnCitationInBibliography
@@ -290,7 +281,6 @@ position_IfIbidWithLocatorIsTrueThenIbidIsTrue
 position_NearNoteSameNote                                          # uncaught exception
 position_ResetNoteNumbers
 punctuation_DefaultYearSuffixDelimiter
-punctuation_DelimiterWithStripPeriodsAndSubstitute2
 punctuation_FieldDuplicates
 punctuation_FrenchOrthography
 punctuation_FullMontyField
@@ -304,7 +294,6 @@ quotes_Punctuation
 quotes_PunctuationNasty
 quotes_PunctuationWithInnerQuote
 quotes_QuotesUnderQuotesFalse
-simplespace_case1
 sort_AguStyle
 sort_AguStyleReverseGroups
 sort_AuthorDateWithYearSuffix


### PR DESCRIPTION
We've been missing handling of double spaces and punctuation forever. I handed it over to Claude and it came up with what appears to be a reasonable solution. This fixes 11 previously-failing citeproc-test fixtures with no regressions (491 -> 502 passing).